### PR TITLE
Add Kconfig options for CDC ACM VID/PID

### DIFF
--- a/usb/class/Kconfig
+++ b/usb/class/Kconfig
@@ -32,6 +32,22 @@ config CDC_ACM_PORT_NAME
 	help
 	Port name through which CDC ACM class device driver is accessed
 
+config CDC_ACM_VID
+	hex
+	prompt "CDC ACM Device Class Driver Vendor ID"
+	depends on USB_CDC_ACM
+	default 8087
+	help
+	Sets the Vendor ID used by the CDC ACM Device Class Driver
+
+config CDC_ACM_PID
+	hex
+	prompt "CDC ACM Device Class Driver Product ID"
+	depends on USB_CDC_ACM
+	default 0AB6
+	help
+	Sets the Product ID used by the CDC ACM Device Class Driver
+
 config SYS_LOG_USB_CDC_ACM_LEVEL
 	int
 	prompt "USB CDC ACM device class driver log level"

--- a/usb/class/cdc_acm.h
+++ b/usb/class/cdc_acm.h
@@ -58,10 +58,10 @@ struct cdc_acm_notification {
 } __packed;
 
 /* Intel vendor ID */
-#define CDC_VENDOR_ID	0x8086
+#define CDC_VENDOR_ID	0x8087
 
 /* Product Id, random value */
-#define CDC_PRODUCT_ID	0xF8A1
+#define CDC_PRODUCT_ID	0x0AB6
 
 
 /* Max packet size for Bulk endpoints */

--- a/usb/class/cdc_acm.h
+++ b/usb/class/cdc_acm.h
@@ -58,10 +58,10 @@ struct cdc_acm_notification {
 } __packed;
 
 /* Intel vendor ID */
-#define CDC_VENDOR_ID	0x8087
+#define CDC_VENDOR_ID	CONFIG_CDC_ACM_VID
 
 /* Product Id, random value */
-#define CDC_PRODUCT_ID	0x0AB6
+#define CDC_PRODUCT_ID	CONFIG_CDC_ACM_PID
 
 
 /* Max packet size for Bulk endpoints */


### PR DESCRIPTION
Currently the CDC ACM driver uses hardcoded values for Vendor & Product IDs. This change allows those values to be set through Kconfig.
