### PR TITLE
cdc_acm.c: make cdc-acm configurable at runtime

### DIFF
--- a/include/cdc_acm_config.h
+++ b/include/cdc_acm_config.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *
+ * Copyright(c) 2015,2016,2017 Intel Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * * Neither the name of Intel Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ***************************************************************************/
+
+/**
+ * @file
+ * @brief CDC ACM device class driver; descriptor configuration structure
+ * header file
+ *
+ * Header file for USB CDC ACM device class driver descriptor configuration
+ * structure
+ */
+
+#ifndef __CDC_ACM_CONFIG_H__
+#define __CDC_ACM_CONFIG_H__
+
+#define MAX_STRING_DESC_SIZE    128 /* 64 unicode characters */
+
+/* Data structure to allow configurable items within the
+ * device descriptor */
+typedef struct cdc_acm_cfg {
+    uint16_t vendor_id;
+    uint16_t product_id;
+    uint8_t vendor_string[MAX_STRING_DESC_SIZE / 2];
+    uint8_t product_string[MAX_STRING_DESC_SIZE / 2];
+    uint8_t serial_string[MAX_STRING_DESC_SIZE / 2];
+} cdc_acm_cfg_t;
+
+#endif /* __CDC_ACM_CONFIG_H__ */

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -25,6 +25,35 @@ config USB_CDC_ACM
 	help
 	USB CDC ACM device class driver
 
+config USB_CDC_ACM_CONFIGURABLE
+	bool
+	prompt "USB CDC ACM device descriptor is configurable"
+	default n
+	help
+	Allows alternative data to be supplied for the USB device descriptor
+	beore it is registered. When this is enabled, you must define a callback
+	function called cdc_acm_descriptor_callback, which populates a passed
+	configuration structure.
+
+	Example;
+
+	#include <zephyr.h>
+	#include <cdc_acm_config.h>
+
+	char *vendor = "Vendor";
+	char *product = "Product";
+	char *serial = "0.1.234";
+
+	void cdc_acm_descriptor_callback (cdc_acm_cfg_t *cfg)
+	{
+		cfg->vendor_id = 0xAABB;
+		cfg->product_id = 0xCCDD;
+
+		memcpy(cfg->vendor_string, vendor, sizeof(cfg->vendor_string));
+		memcpy(cfg->product_string, product, sizeof(cfg->product_string));
+		memcpy(cfg->serial_string, serial, sizeof(cfg->serial_string));
+	}
+
 config CDC_ACM_PORT_NAME
 	string "CDC ACM class device driver port name"
 	depends on USB_CDC_ACM

--- a/subsys/usb/class/cdc_acm.h
+++ b/subsys/usb/class/cdc_acm.h
@@ -60,9 +60,14 @@ struct cdc_acm_notification {
 /* Intel vendor ID */
 #define CDC_VENDOR_ID	0x8087
 
+/* Vendor code byte offset in device descriptor */
+#define CDC_VENDOR_OFFSET 8
+
 /* Product Id, random value */
 #define CDC_PRODUCT_ID	0x0AB6
 
+/* Product code byte offset in device descriptor */
+#define CDC_PRODUCT_OFFSET 10
 
 /* Max packet size for Bulk endpoints */
 #define CDC_BULK_EP_MPS		64
@@ -81,6 +86,9 @@ struct cdc_acm_notification {
 #define CDC1_NUM_EP		0x01
 /* Number of Endpoints in the second interface */
 #define CDC2_NUM_EP		0x02
+
+/* Number of string descriptors */
+#define CDC_NUM_STRINGS 0x03
 
 #define CDC_ENDP_INT	0x81
 #define CDC_ENDP_OUT	0x03
@@ -125,5 +133,15 @@ struct cdc_acm_notification {
  */
 #define CDC_CONF_SIZE   (USB_CONFIGURATION_DESC_SIZE + \
 	(2 * USB_INTERFACE_DESC_SIZE) + (3 * USB_ENDPOINT_DESC_SIZE) + 19)
+
+#define STRING_DESCS_SIZE (USB_STRING_DESC_SIZE + \
+    ((MAX_STRING_DESC_SIZE + 2) * CDC_NUM_STRINGS))
+
+#define DEVICE_DESC_SIZE  (USB_CONFIGURATION_DESC_SIZE + \
+    (2 * USB_INTERFACE_DESC_SIZE) + (3 * USB_ENDPOINT_DESC_SIZE) + \
+    USB_DEVICE_DESC_SIZE + USB_HFUNC_DESC_SIZE + USB_CMFUNC_DESC_SIZE + \
+    USB_ACMFUNC_DESC_SIZE + USB_UFUNC_DESC_SIZE)
+
+#define CDC_ACM_DESC_SIZE   (DEVICE_DESC_SIZE + STRING_DESCS_SIZE)
 
 #endif /* __CDC_ACM_H__ */


### PR DESCRIPTION
This allows a developer to define a callback function in their
application code which takes a pointer to a configuration structure.

This structure will be used by the cdc-acm driver at device enumeration
time to generate the device descriptor. The callback function, if
defined, will be invoked at device enumeration, right before the
descriptor is generated.

In order to use this feature, you must enable
CONFIG_USB_CDC_ACM_CONFIGURABLE; for details on how to implement the
callback function once this option is enabled, see the 'help' section in
subsys/usb/class/Kconfig