### PR TITLE
Allow cdc-acm to be configurable at runtime

### DIFF
--- a/include/cdc_acm_config.h
+++ b/include/cdc_acm_config.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *
+ * Copyright(c) 2015,2016,2017 Intel Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * * Neither the name of Intel Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ***************************************************************************/
+
+/**
+ * @file
+ * @brief CDC ACM device class driver; descriptor configuration structure
+ * header file
+ *
+ * Header file for USB CDC ACM device class driver descriptor configuration
+ * structure
+ */
+
+#ifndef __CDC_ACM_CONFIG_H__
+#define __CDC_ACM_CONFIG_H__
+
+#define MAX_STRING_DESC_SIZE    128 /* 64 unicode characters */
+
+/* Data structure to allow configurable items within the
+ * device descriptor */
+typedef struct cdc_acm_cfg {
+    uint16_t vendor_id;
+    uint16_t product_id;
+    uint8_t vendor_string[MAX_STRING_DESC_SIZE / 2];
+    uint8_t product_string[MAX_STRING_DESC_SIZE / 2];
+    uint8_t serial_string[MAX_STRING_DESC_SIZE / 2];
+} cdc_acm_cfg_t;
+
+#endif /* __CDC_ACM_CONFIG_H__ */

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -15,6 +15,35 @@ config USB_CDC_ACM
 	help
 	USB CDC ACM device class driver
 
+config USB_CDC_ACM_CONFIGURABLE
+	bool
+	prompt "USB CDC ACM device descriptor is configurable"
+	default n
+	help
+	Allows alternative data to be supplied for the USB device descriptor
+	beore it is registered. When this is enabled, you must define a callback
+	function called cdc_acm_descriptor_callback, which populates a passed
+	configuration structure.
+
+	Example;
+
+	#include <zephyr.h>
+	#include <cdc_acm_config.h>
+
+	char *vendor = "Vendor";
+	char *product = "Product";
+	char *serial = "0.1.234";
+
+	void cdc_acm_descriptor_callback (cdc_acm_cfg_t *cfg)
+	{
+		cfg->vendor_id = 0xAABB;
+		cfg->product_id = 0xCCDD;
+
+		memcpy(cfg->vendor_string, vendor, sizeof(cfg->vendor_string));
+		memcpy(cfg->product_string, product, sizeof(cfg->product_string));
+		memcpy(cfg->serial_string, serial, sizeof(cfg->serial_string));
+	}
+
 config CDC_ACM_PORT_NAME
 	string "CDC ACM class device driver port name"
 	depends on USB_CDC_ACM

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -42,6 +42,7 @@
 #include <uart.h>
 #include <string.h>
 #include <misc/byteorder.h>
+#include "cdc_acm_config.h"
 #include "cdc_acm.h"
 #include "usb_device.h"
 #include "usb_common.h"
@@ -74,6 +75,8 @@ struct device *cdc_acm_dev;
 
 static struct k_sem poll_wait_sem;
 
+typedef void (*cdc_acm_desc_cb)(cdc_acm_cfg_t);
+
 /* Device data structure */
 struct cdc_acm_dev_data_t {
 	/* USB device status code */
@@ -100,8 +103,12 @@ struct cdc_acm_dev_data_t {
 	u8_t notification_sent;
 };
 
+#ifdef CONFIG_USB_CDC_ACM_CONFIGURABLE
+    extern void cdc_acm_descriptor_callback (cdc_acm_cfg_t *cfg);
+#endif
+
 /* Structure representing the global USB description */
-static const u8_t cdc_acm_usb_description[] = {
+static u8_t cdc_acm_usb_description[CDC_ACM_DESC_SIZE] = {
 	/* Device descriptor */
 	USB_DEVICE_DESC_SIZE,           /* Descriptor size */
 	USB_DEVICE_DESC,                /* Descriptor type */
@@ -228,22 +235,67 @@ static const u8_t cdc_acm_usb_description[] = {
 	USB_STRING_DESC,                /* Descriptor type */
 	0x09,
 	0x04,
-
-	/* Manufacturer String Descriptor "Intel" */
-	0x0C,
-	USB_STRING_DESC,
-	'I', 0, 'n', 0, 't', 0, 'e', 0, 'l', 0,
-
-	/* Product String Descriptor "CDC-ACM" */
-	0x10,
-	USB_STRING_DESC,
-	'C', 0, 'D', 0, 'C', 0, '-', 0, 'A', 0, 'C', 0, 'M', 0,
-
-	/* Serial Number String Descriptor "00.01" */
-	0x0C,
-	USB_STRING_DESC,
-	'0', 0, '0', 0, '.', 0, '0', 0, '1', 0,
 };
+
+static cdc_acm_cfg_t desc_cfg = {
+    .vendor_id = CDC_VENDOR_ID,
+    .product_id =  CDC_PRODUCT_ID,
+    .vendor_string = "Intel",
+    .product_string = "CDC-ACM",
+    .serial_string = "00.01"
+};
+
+static uint8_t *ascii_to_unicode (uint8_t *in, uint8_t *out, unsigned size)
+{
+    unsigned i, j;
+
+    for (i = 0, j = 0; in[i] && j < size; ++i, j += 2) {
+        out[j] = in[i];
+        out[j + 1] = 0;
+    }
+
+    return out + j;
+}
+
+/* Generates a byte array representing the descriptor for 'string', which
+ * is written to 'out'. The return value is a pointer to the first byte
+ * after the written string descriptor in 'out' */
+static uint8_t *generate_string_desc (char *string, uint8_t *out)
+{
+    int len;
+
+    len = strlen(string) * 2;
+    if ((len + 2) > MAX_STRING_DESC_SIZE)
+        len = MAX_STRING_DESC_SIZE - 2;
+
+    *(out++) = len + 2;
+    *(out++) = USB_STRING_DESC;
+
+    return ascii_to_unicode(string, out, len);
+}
+
+static void generate_cdc_acm_descriptor (uint8_t *desc)
+{
+    uint8_t *pos;
+
+    /* String descriptors begin after string descriptor 0 */
+    pos = cdc_acm_usb_description + DEVICE_DESC_SIZE + USB_STRING_DESC_SIZE;
+
+    /* Read ASCII strings for vendor, product & serial from
+     * temporary configuration structure, generate the unicode
+     * string descriptors and write to cdc_acm_string_desc */
+    pos = generate_string_desc(desc_cfg.vendor_string, pos);
+    pos = generate_string_desc(desc_cfg.product_string, pos);
+    generate_string_desc(desc_cfg.serial_string, pos);
+
+    /* Copy Vendor and Product IDs from temporary configuration
+     * structure into cdc_acm_device_desc */
+    desc[CDC_VENDOR_OFFSET] = LOW_BYTE(desc_cfg.vendor_id);
+    desc[CDC_VENDOR_OFFSET + 1] = HIGH_BYTE(desc_cfg.vendor_id);
+
+    desc[CDC_PRODUCT_OFFSET] = LOW_BYTE(desc_cfg.product_id);
+    desc[CDC_PRODUCT_OFFSET + 1] = HIGH_BYTE(desc_cfg.product_id);
+}
 
 /**
  * @brief Handler called for Class requests not handled by the USB stack.
@@ -497,6 +549,11 @@ static int cdc_acm_init(struct device *dev)
 
 	cdc_acm_config.interface.payload_data = dev_data->interface_data;
 	cdc_acm_dev = dev;
+
+#ifdef CONFIG_USB_CDC_ACM_CONFIGURABLE
+    cdc_acm_descriptor_callback(&desc_cfg);
+#endif
+    generate_cdc_acm_descriptor(cdc_acm_usb_description);
 
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&cdc_acm_config);

--- a/subsys/usb/class/cdc_acm.h
+++ b/subsys/usb/class/cdc_acm.h
@@ -60,9 +60,14 @@ struct cdc_acm_notification {
 /* Intel vendor ID */
 #define CDC_VENDOR_ID	0x8086
 
+/* Vendor code byte offset in device descriptor */
+#define CDC_VENDOR_OFFSET 8
+
 /* Product Id, random value */
 #define CDC_PRODUCT_ID	0xF8A1
 
+/* Product code byte offset in device descriptor */
+#define CDC_PRODUCT_OFFSET 10
 
 /* Max packet size for Bulk endpoints */
 #define CDC_BULK_EP_MPS		64
@@ -81,6 +86,9 @@ struct cdc_acm_notification {
 #define CDC1_NUM_EP		0x01
 /* Number of Endpoints in the second interface */
 #define CDC2_NUM_EP		0x02
+
+/* Number of string descriptors */
+#define CDC_NUM_STRINGS 0x03
 
 #define CDC_ENDP_INT	0x81
 #define CDC_ENDP_OUT	0x03
@@ -125,5 +133,15 @@ struct cdc_acm_notification {
  */
 #define CDC_CONF_SIZE   (USB_CONFIGURATION_DESC_SIZE + \
 	(2 * USB_INTERFACE_DESC_SIZE) + (3 * USB_ENDPOINT_DESC_SIZE) + 19)
+
+#define STRING_DESCS_SIZE (USB_STRING_DESC_SIZE + \
+    ((MAX_STRING_DESC_SIZE + 2) * CDC_NUM_STRINGS))
+
+#define DEVICE_DESC_SIZE  (USB_CONFIGURATION_DESC_SIZE + \
+    (2 * USB_INTERFACE_DESC_SIZE) + (3 * USB_ENDPOINT_DESC_SIZE) + \
+    USB_DEVICE_DESC_SIZE + USB_HFUNC_DESC_SIZE + USB_CMFUNC_DESC_SIZE + \
+    USB_ACMFUNC_DESC_SIZE + USB_UFUNC_DESC_SIZE)
+
+#define CDC_ACM_DESC_SIZE   (DEVICE_DESC_SIZE + STRING_DESCS_SIZE)
 
 #endif /* __CDC_ACM_H__ */


### PR DESCRIPTION
This allows a developer to define a callback function in their
application code which takes a pointer to a configuration structure.

This structure will be used by the cdc-acm driver at device enumeration
time to generate the device descriptor. The callback function, if
defined, will be invoked at device enumeration, right before the
descriptor is generated.

In order to use this feature, you must enable
CONFIG_USB_CDC_ACM_CONFIGURABLE; for details on how to implement the
callback function once this option is enabled, see the 'help' section in
subsys/usb/class/Kconfig